### PR TITLE
Use RDF::XSD instead of XSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,15 @@ without the `RDF::` prefix.  For example:
     class CD
       include Spira::Resource
       base_uri 'http://example.org/cds'
-      property :name,   :predicate => DC.title,   :type => XSD.string
+      property :name,   :predicate => DC.title,   :type => RDF::XSD.string
       property :artist, :predicate => URI.new('http://example.org/vocab/artist'), :type => :artist
     end
     
     class Artist
       include Spira::Resource
       base_uri 'http://example.org/artists'
-      property :name, :predicate => DC.title, :type => XSD.string
-      has_many :cds,  :predicate => URI.new('http://example.org/vocab/published_cd'), :type => XSD.string
+      property :name, :predicate => DC.title, :type => RDF::XSD.string
+      has_many :cds,  :predicate => URI.new('http://example.org/vocab/published_cd'), :type => RDF::XSD.string
     end
 
 Then use your model classes, in a way more or less similar to any number of ORMs:
@@ -256,7 +256,7 @@ is usually expressed as a URI.  Here is the built-in Spira Integer class:
           RDF::Literal.new(value)
         end
     
-        register_alias XSD.integer
+        register_alias RDF::XSD.integer
       end
     end
 
@@ -265,7 +265,7 @@ Classes can now use this particular type like so:
     class Test
       include Spira::Resource
       property :test1, :type => Integer
-      property :test2, :type => XSD.integer
+      property :test2, :type => RDF::XSD.integer
     end
 
 Spira classes include the Spira::Types namespace, where several default types

--- a/lib/spira/type.rb
+++ b/lib/spira/type.rb
@@ -19,7 +19,7 @@ module Spira
   #         RDF::Literal.new(value)
   #       end
   #       
-  #       register_alias XSD.integer
+  #       register_alias RDF::XSD.integer
   #     end
   #
   # This example will serialize and deserialize integers.  It's included with
@@ -27,7 +27,7 @@ module Spira
   # integer property on a Spira resource:
   #
   #     property :age, :predicate => FOAF.age, :type => Integer
-  #     property :age, :predicate => FOAF.age, :type => XSD.integer
+  #     property :age, :predicate => FOAF.age, :type => RDF::XSD.integer
   #
   # `Spira::Type`s include the RDF namespace and thus have all of the base RDF
   # vocabularies available to them without the `RDF::` prefix.

--- a/lib/spira/types/boolean.rb
+++ b/lib/spira/types/boolean.rb
@@ -19,13 +19,13 @@ module Spira::Types
 
     def self.serialize(value)
       if value
-        RDF::Literal.new(true, :datatype => XSD.boolean)
+        RDF::Literal.new(true, :datatype => RDF::XSD.boolean)
       else 
-        RDF::Literal.new(false, :datatype => XSD.boolean)
+        RDF::Literal.new(false, :datatype => RDF::XSD.boolean)
       end
     end
 
-    register_alias XSD.boolean
+    register_alias RDF::XSD.boolean
 
   end
 end

--- a/lib/spira/types/decimal.rb
+++ b/lib/spira/types/decimal.rb
@@ -20,10 +20,10 @@ module Spira::Types
     end
 
     def self.serialize(value)
-      RDF::Literal.new(value.is_a?(BigDecimal) ? value.to_s('F') : value.to_s, :datatype => XSD.decimal)
+      RDF::Literal.new(value.is_a?(BigDecimal) ? value.to_s('F') : value.to_s, :datatype => RDF::XSD.decimal)
     end
 
-    register_alias XSD.decimal
+    register_alias RDF::XSD.decimal
 
   end
 end

--- a/lib/spira/types/float.rb
+++ b/lib/spira/types/float.rb
@@ -18,11 +18,11 @@ module Spira::Types
     end
 
     def self.serialize(value)
-      RDF::Literal.new(value.to_f, :datatype => XSD.double)
+      RDF::Literal.new(value.to_f, :datatype => RDF::XSD.double)
     end
 
-    register_alias XSD.float
-    register_alias XSD.double
+    register_alias RDF::XSD.float
+    register_alias RDF::XSD.double
 
   end
 end

--- a/lib/spira/types/integer.rb
+++ b/lib/spira/types/integer.rb
@@ -21,7 +21,7 @@ module Spira::Types
       RDF::Literal.new(value)
     end
 
-    register_alias XSD.integer
+    register_alias RDF::XSD.integer
 
   end
 end

--- a/lib/spira/types/string.rb
+++ b/lib/spira/types/string.rb
@@ -21,7 +21,7 @@ module Spira::Types
       RDF::Literal.new(value.to_s)
     end
 
-    register_alias XSD.string
+    register_alias RDF::XSD.string
 
   end
 end

--- a/spec/property_types.spec
+++ b/spec/property_types.spec
@@ -14,7 +14,7 @@ describe 'types for properties' do
           default_vocabulary RDF::URI.new('http://example.org/vocab')
           base_uri RDF::URI.new('http://example.org/props')
 
-          property :test, :type => XSD.non_existent_type
+          property :test, :type => RDF::XSD.non_existent_type
         end
       }.should raise_error TypeError
     end
@@ -38,7 +38,7 @@ describe 'types for properties' do
           default_vocabulary RDF::URI.new('http://example.org/vocab')
           base_uri RDF::URI.new('http://example.org/props')
 
-          property :test, :type => XSD.string
+          property :test, :type => RDF::XSD.string
         end
       }.should_not raise_error TypeError
     end
@@ -70,14 +70,14 @@ describe 'types for properties' do
         include Spira::Type
       
         def self.serialize(value)
-          RDF::Literal.new(value, :datatype => XSD.test_type)
+          RDF::Literal.new(value, :datatype => RDF::XSD.test_type)
         end
 
         def self.unserialize(value)
           value.value
         end
 
-        register_alias XSD.test_type
+        register_alias RDF::XSD.test_type
       end
 
       class ::PropTest
@@ -88,7 +88,7 @@ describe 'types for properties' do
         base_uri RDF::URI.new('http://example.org/props')
       
         property :test,      :type => TestType
-        property :xsd_test,  :type => XSD.test_type
+        property :xsd_test,  :type => RDF::XSD.test_type
       end
     end
 


### PR DESCRIPTION
I ran into a problem a while back using Spira in a Ruby 1.8.7 project that happens to also require 'xsd/charset'. This defines a top level XSD constant, which conflicts with Spira's use of XSD. I monkey patched this before, but now here's a real fix changing all instances of XSD to RDF::XSD. =)

I'd also be willing to add some Travis integration.
