### PR TITLE
raise NoRepositoryError when repository is not set

### DIFF
--- a/lib/spira/persistence.rb
+++ b/lib/spira/persistence.rb
@@ -18,7 +18,7 @@ module Spira
       #
       # @return [RDF::Repository, nil]
       def repository
-        Spira.repository(repository_name)
+        Spira.repository(repository_name) || raise(NoRepositoryError)
       end
 
       ##
@@ -377,13 +377,10 @@ module Spira
     # This resource will block if the underlying repository
     # blocks the next time it accesses attributes.
     #
-    # If repository is not defined, the attributes are just not set,
-    # instead of raising a Spira::NoRepositoryError.
-    #
     # NB: "props" argument is ignored, it is handled in Base
     #
     def reload(props = {})
-      sts = self.class.repository && self.class.repository.query(:subject => subject)
+      sts = self.class.repository.query(:subject => subject)
       self.class.properties.each do |name, options|
         name = name.to_s
         if sts

--- a/spec/basic_spec.rb
+++ b/spec/basic_spec.rb
@@ -20,159 +20,172 @@ describe Spira do
     end
   end
 
-  before :each do
-    @person_repository = RDF::Repository.load(fixture('bob.nt'))
-    Spira.add_repository(:default, @person_repository)
-  end
-
-  context "The person fixture" do
-
-    it "should know its source" do
-      Person.repository.should be_a RDF::Repository
-      Person.repository.should equal @person_repository
+  context "with repository given" do
+    before :each do
+      @person_repository = RDF::Repository.load(fixture('bob.nt'))
+      Spira.add_repository(:default, @person_repository)
     end
 
-    context "when instantiating new URIs" do
+    context "The person fixture" do
 
-      it "should offer a for method" do
-        Person.should respond_to :for
+      it "should know its source" do
+        Person.repository.should be_a RDF::Repository
+        Person.repository.should equal @person_repository
       end
 
-      it "should be able to create new instances for non-existing resources" do
-        lambda { Person.for(RDF::URI.new('http://example.org/newperson')) }.should_not raise_error
+      context "when instantiating new URIs" do
+
+        it "should offer a for method" do
+          Person.should respond_to :for
+        end
+
+        it "should be able to create new instances for non-existing resources" do
+          lambda { Person.for(RDF::URI.new('http://example.org/newperson')) }.should_not raise_error
+        end
+
+        it "should create Person instances" do
+          Person.for(RDF::URI.new('http://example.org/newperson')).should be_a Person
+        end
+
+        context "with attributes given" do
+          before :each do
+            @alice = Person.for 'alice', :age => 30, :name => 'Alice'
+          end
+
+          it "should have properties if it had them as attributes on creation" do
+            @alice.age.should == 30
+            @alice.name.should == 'Alice'
+          end
+
+          it "should save updated properties" do
+            @alice.age = 16
+            @alice.age.should == 16
+          end
+
+        end
       end
 
-      it "should create Person instances" do
-        Person.for(RDF::URI.new('http://example.org/newperson')).should be_a Person
+      context "when instantiating existing URIs" do
+
+        it "should return a Person for a non-existent URI" do
+          Person.for('nobody').should be_a Person
+        end
+
+        it "should return an empty Person for a non-existent URI" do
+          person = Person.for('nobody')
+          person.age.should be_nil
+          person.name.should be_nil
+        end
+
       end
 
       context "with attributes given" do
         before :each do
           @alice = Person.for 'alice', :age => 30, :name => 'Alice'
+          @bob   = Person.for 'bob',   :name => 'Bob Smith II'
         end
 
-        it "should have properties if it had them as attributes on creation" do
-          @alice.age.should == 30
-          @alice.name.should == 'Alice'
+        it "should overwrite existing properties with given attributes" do
+          @bob.name.should == "Bob Smith II"
         end
 
-        it "should save updated properties" do
-          @alice.age = 16
-          @alice.age.should == 16
+        it "should not overwrite existing properties which are not given" do
+          @bob.age.should == 15
         end
 
-      end
-    end
-
-    context "when instantiating existing URIs" do
-
-      it "should return a Person for a non-existent URI" do
-        Person.for('nobody').should be_a Person
-      end
-
-      it "should return an empty Person for a non-existent URI" do
-        person = Person.for('nobody')
-        person.age.should be_nil
-        person.name.should be_nil
-      end
-
-    end
-
-    context "with attributes given" do
-      before :each do
-        @alice = Person.for 'alice', :age => 30, :name => 'Alice'
-        @bob   = Person.for 'bob',   :name => 'Bob Smith II'
-      end
-
-      it "should overwrite existing properties with given attributes" do
-        @bob.name.should == "Bob Smith II"
-      end
-
-      it "should not overwrite existing properties which are not given" do
-        @bob.age.should == 15
-      end
-
-      it "should allow property updating" do
-        @bob.age = 16
-        @bob.age.should == 16
-      end
-    end
-
-    context "A newly-created person" do
-
-      before :each do
-        @person = Person.for 'http://example.org/example/people/alice'
-      end
-
-      context "in respect to some general methods" do
-        it "should #uri" do
-          @person.should respond_to :uri
-        end
-
-        it "should return a RDF::URI from #uri" do
-          @person.uri.should be_a RDF::URI
-        end
-
-        it "should return the correct URI from #uri" do
-          @person.uri.to_s.should == 'http://example.org/example/people/alice'
-        end
-
-        it "should support #to_uri" do
-          @person.should respond_to :to_uri
-        end
-
-        it "should return the correct URI from #to_uri" do
-          @person.to_uri.to_s.should == 'http://example.org/example/people/alice'
-        end
-
-        it "should support #to_rdf" do
-          @person.should respond_to :to_rdf
-        end
-
-        it "should return an RDF::Enumerable for #to_rdf" do
-          @person.to_rdf.should be_a RDF::Enumerable
+        it "should allow property updating" do
+          @bob.age = 16
+          @bob.age.should == 16
         end
       end
 
-      context "using getters and setters" do
-        it "should have a name method" do
-          @person.should respond_to :name
+      context "A newly-created person" do
+
+        before :each do
+          @person = Person.for 'http://example.org/example/people/alice'
         end
 
-        it "should have an age method" do
-          @person.should respond_to :age
+        context "in respect to some general methods" do
+          it "should #uri" do
+            @person.should respond_to :uri
+          end
+
+          it "should return a RDF::URI from #uri" do
+            @person.uri.should be_a RDF::URI
+          end
+
+          it "should return the correct URI from #uri" do
+            @person.uri.to_s.should == 'http://example.org/example/people/alice'
+          end
+
+          it "should support #to_uri" do
+            @person.should respond_to :to_uri
+          end
+
+          it "should return the correct URI from #to_uri" do
+            @person.to_uri.to_s.should == 'http://example.org/example/people/alice'
+          end
+
+          it "should support #to_rdf" do
+            @person.should respond_to :to_rdf
+          end
+
+          it "should return an RDF::Enumerable for #to_rdf" do
+            @person.to_rdf.should be_a RDF::Enumerable
+          end
         end
 
-        it "should return nil for unset properties" do
-          @person.name.should == nil
-        end
+        context "using getters and setters" do
+          it "should have a name method" do
+            @person.should respond_to :name
+          end
 
-        it "should allow setting a name" do
-          lambda { @person.name = "Bob Smith" }.should_not raise_error
-        end
+          it "should have an age method" do
+            @person.should respond_to :age
+          end
 
-        it "should allow getting a name" do
-          @person.name = "Bob Smith"
-          @person.name.should == "Bob Smith"
-        end
+          it "should return nil for unset properties" do
+            @person.name.should == nil
+          end
 
-        it "should allow setting an age" do
-          lambda { @person.age = 15 }.should_not raise_error
-        end
+          it "should allow setting a name" do
+            lambda { @person.name = "Bob Smith" }.should_not raise_error
+          end
 
-        it "should allow getting an age" do
-          @person.age = 15
-          @person.age.should == 15
-        end
+          it "should allow getting a name" do
+            @person.name = "Bob Smith"
+            @person.name.should == "Bob Smith"
+          end
 
-        it "should correctly set more than one property" do
-          @person.age = 15
-          @person.name = "Bob Smith"
-          @person.age.should == 15
-          @person.name.should == "Bob Smith"
+          it "should allow setting an age" do
+            lambda { @person.age = 15 }.should_not raise_error
+          end
+
+          it "should allow getting an age" do
+            @person.age = 15
+            @person.age.should == 15
+          end
+
+          it "should correctly set more than one property" do
+            @person.age = 15
+            @person.name = "Bob Smith"
+            @person.age.should == 15
+            @person.name.should == "Bob Smith"
+          end
         end
       end
     end
+  end
 
+  context "without a repository" do
+    before { Spira.clear_repositories! }
+
+    let(:bob) { RDF::URI("http://example.org/example/people/bob").as(Person) }
+
+    context "when saved" do
+      it "should raise NoRepositoryError exception" do
+        expect { bob.save }.to raise_exception Spira::NoRepositoryError
+      end
+    end
   end
 end

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -73,28 +73,11 @@ describe Spira do
   context "classes using the default repository" do
 
     context "without a set repository" do
-      before :each do
-        Spira.clear_repositories!
-        @event = Event.for(RDF::URI.new('http://example.org/events/this-one'))
-      end
+      before { Spira.clear_repositories! }
 
-      it "should return nil for a repository which does not exist" do
-        Event.repository.should be_nil
+      it "should raise NoRepositoryError if a repository does not exist" do
+        expect { Event.repository }.to raise_error Spira::NoRepositoryError
       end
-
-      it "should not raise an error when accessing an attribute" do
-        lambda { @event.name }.should_not raise_error
-      end
-
-      it "should raise an error to call instance#save" do
-        @event.name = "test"
-        lambda { @event.save }.should raise_error
-      end
-
-      it "should raise an error to call instance#destroy" do
-        lambda { @event.destroy }.should raise_error
-      end
-
     end
 
     context "with a set repository" do
@@ -123,28 +106,19 @@ describe Spira do
   context "classes using a named repository" do
 
     context "without a set repository" do
-      before :each do
-        Spira.clear_repositories!
+      before { Spira.clear_repositories! }
+
+      it "should raise NoRepositoryError if a repository does not exist" do
+        expect { Stadium.repository }.to raise_error Spira::NoRepositoryError
       end
 
-      it "should return nil for a repository which does not exist" do
-        Stadium.repository.should be_nil
-      end
-
-      it "should not raise an error when accessing an attribute" do
-        stadium = RDF::URI('http://example.org/stadiums/that-one').as(Stadium)
-        lambda { stadium.name }.should_not raise_error
-      end
-
-      it "should raise an error to call instance#save" do
-        stadium = Stadium.for(RDF::URI.new('http://example.org/stadiums/this-one'))
-        stadium.name = 'test'
-        lambda { stadium.save }.should raise_error
+      it "should raise an error when instantiating" do
+        expect { RDF::URI('http://example.org/stadiums/that-one').as(Stadium) }.to raise_error Spira::NoRepositoryError
       end
     end
 
     context "with a set repository" do
-      before :each do
+      before do
         Spira.clear_repositories!
         @repo = RDF::Repository.new
         Spira.add_repository(:stadium, @repo)


### PR DESCRIPTION
Here you go. Fixes https://github.com/ruby-rdf/spira/issues/13 by raising exception when repository is not set. This should make handling of Spira resources more "user-friendly".
