### PR TITLE
Using #simple? instead of #plain? for literals without language

### DIFF
--- a/lib/spira/base.rb
+++ b/lib/spira/base.rb
@@ -337,7 +337,7 @@ module Spira
     end
 
     def unserialize_localized_properties(values, locale)
-      v = values.detect { |s| s.language == locale || s.plain? }
+      v = values.detect { |s| s.language == locale || s.simple? }
       v && v.object
     end
 


### PR DESCRIPTION
RDF::Literal#plain? allows a language tag for the literal, so `unserialize_localized_properties` should use RDF::Literal#simple? instead.

@abrisse could you take a look and confirm that everything's as you originally intended?
Apparently, you're not using RDF.rb which is "bundled" for development (1.0.6 here), so things might be different there.

That said, I vote for getting `Gemfile.lock` back into the repository, @gkellogg ;-)
