### PR TITLE
Reduce number of repository operations required to read and write objects

### DIFF
--- a/lib/spira/base.rb
+++ b/lib/spira/base.rb
@@ -119,6 +119,11 @@ module Spira
     def initialize(props = {}, options = {})
       @subject = props.delete(:_subject) || RDF::Node.new
 
+      @new_record = true
+      if !options[:new_record].nil?
+        @new_record = options[:new_record]
+      end
+
       @attributes = {}
       reload props
 

--- a/lib/spira/persistence.rb
+++ b/lib/spira/persistence.rb
@@ -445,7 +445,7 @@ module Spira
           end
         else
           if attribute_changed?(name.to_s)
-            repo.delete [subject, property[:predicate], @attributes[name]]
+            repo.delete [subject, property[:predicate], nil]
             store_attribute(name, value, property[:predicate], repo)
           end
         end

--- a/lib/spira/persistence.rb
+++ b/lib/spira/persistence.rb
@@ -366,7 +366,7 @@ module Spira
     # NB: "props" argument is ignored, it is handled in Base
     #
     def reload(props = {})
-      sts = self.class.repository.query(:subject => subject)
+      sts = self.class.repository.query(:subject => subject).entries
       self.class.properties.each do |name, options|
         name = name.to_s
         if sts


### PR DESCRIPTION
This patch, in conjunction with separate patch against sparql-client (https://github.com/ruby-rdf/sparql-client/pull/45) make it possible to use Spira with a SPARQL/Update repository backend.  These changes eliminate unnecessary round trips to the repository by caching results and batching up queries.
