### PR TITLE
include ActiveModel::Serialization on Spira::Base

### DIFF
--- a/lib/spira/base.rb
+++ b/lib/spira/base.rb
@@ -20,6 +20,7 @@ module Spira
     extend ActiveModel::Naming
     include ActiveModel::Conversion
     include ActiveModel::Dirty
+    include ActiveModel::Serialization
 
     include ::RDF, ::RDF::Enumerable, ::RDF::Queryable
 


### PR DESCRIPTION
in order to work with active_model_serializers, as described in this issue: https://github.com/rails-api/active_model_serializers/issues/520