### PR TITLE
Add the XSD.Time type.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :development, :test do
   gem 'rdf-spec',       github: "ruby-rdf/rdf-spec",        branch: "develop"
   gem 'rdf-turtle',     github: "ruby-rdf/rdf-turtle",      branch: "develop"
   gem 'rdf-vocab',      github: "ruby-rdf/rdf-vocab",       branch: "develop"
-  gem 'sxp',            github: "gkellogg/sxp-ruby",        branch: "develop"
+  gem 'sxp',            github: "gkellogg/sxp-ruby",        branch: "master"
   gem 'rake',           '~> 10.0'
   gem 'redcarpet',      '~> 3.2.2' unless RUBY_ENGINE == 'jruby'
   gem 'byebug',         platform: :mri

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,6 @@ desc 'Run specs'
 task 'spec' do
   RSpec::Core::RakeTask.new("spec") do |t|
     t.pattern = 'spec/**/*.{spec,rb}'
-    t.rcov = false
     t.rspec_opts = ["-c"]
   end
 end
@@ -19,8 +18,7 @@ desc 'Run specs with backtrace'
 task 'tracespec' do
   RSpec::Core::RakeTask.new("tracespec") do |t|
     t.pattern = 'spec/**/*.{spec,rb}'
-    t.rcov = false
-    t.rspec_opts = ["-bcfn"]
+    t.rspec_opts = ["-bcf documentation"]
   end
 end
 
@@ -28,7 +26,6 @@ desc 'Run coverage'
 task 'coverage' do
   RSpec::Core::RakeTask.new("coverage") do |t|
     t.pattern = 'spec/**/*.{spec,rb}'
-    t.rcov = true
     t.rspec_opts = ["-c"]
   end
 end

--- a/lib/spira/types/time.rb
+++ b/lib/spira/types/time.rb
@@ -1,0 +1,26 @@
+module Spira::Types
+
+  ##
+  # A {Spira::Type} for times.  Values will be associated with the
+  # `XSD.time` type.
+  #
+  # A {Spira::Resource} property can reference this type as
+  # `Spira::Types::Time`, `Time`, or `XSD.time`.
+  #
+  # @see Spira::Type
+  # @see http://rdf.rubyforge.org/RDF/Literal.html
+  class Time
+    include Spira::Type
+
+    def self.unserialize(value)
+      object = value.object.to_time
+    end
+
+    def self.serialize(value)
+      RDF::Literal.new(value, :datatype => XSD.time)
+    end
+
+    register_alias XSD.time
+
+  end
+end

--- a/spec/types/time_spec.rb
+++ b/spec/types/time_spec.rb
@@ -1,0 +1,25 @@
+require File.dirname(File.expand_path(__FILE__)) + '/../spec_helper'
+
+describe Spira::Types::Time do
+
+  before :all do
+    @time = Time.now
+  end
+
+  context "when serializing" do
+    it "should serialize times to XSD times" do
+      serialized = Spira::Types::Time.serialize(@time)
+      expect(serialized).to be_a RDF::Literal
+      expect(serialized).to have_datatype
+      expect(serialized.datatype).to eql RDF::XSD.time
+      expect(serialized).to eql RDF::Literal.new(@time, :datatype => RDF::XSD.time)
+    end
+  end
+
+  context "when unserializing" do
+    it "should unserialize XSD times to times" do
+      value = Spira::Types::Time.unserialize(RDF::Literal.new(@time, :datatype => RDF::XSD.time))
+      expect(value).to eq @time
+    end
+  end
+end


### PR DESCRIPTION
I added the XSD.Time type and its specs. I also fixed the Gemfile & the Rakefile.

The Gemfile's problem was that the SXP gem did not have a 'develop' branch anymore.

The Rakefile's problem was that Rspec changed its API and the #rcov accessor didn't exist anymore on RSpec::Core::RakeTask.