### PR TITLE
Add has_one association

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,18 @@ class CD < Spira::Base
   configure :base_uri => 'http://example.org/cds'
   property :name,   :predicate => RDF::Vocab::DC.title,   :type => XSD.string
   property :artist, :predicate => RDF::URI.new('http://example.org/vocab/artist'), :type => :artist
+  has_one :label, :predicate => RDF::URI.new('http://example.org/vocab/label'), :type => :label
 end
 
 class Artist < Spira::Base
   configure :base_uri => 'http://example.org/artists'
   property :name, :predicate => RDF::Vocab::DC.title, :type => XSD.string
-  has_many :cds,  :predicate => RDF::URI.new('http://example.org/vocab/published_cd'), :type => XSD.string
+  has_many :cds,  :predicate => RDF::URI.new('http://example.org/vocab/published_cd'), :type => :cd
+end
+
+class Label < Spira::Base
+  configure :base_uri => 'http://example.org/labels'
+  property :name,   :predicate => RDF::Vocab::DC.title,   :type => XSD.string
 end
 ```
 
@@ -133,8 +139,12 @@ cd = CD.for("queens-greatest-hits")
 cd.name = "Queen's greatest hits"
 artist = Artist.for("queen")
 artist.name = "Queen"
+label = Label.for("bfc")
+label.name = "Big Friendly Company"
 
+label.save!
 cd.artist = artist
+cd.label = label
 cd.save!
 artist.cds = [cd]
 artist.save!
@@ -142,6 +152,8 @@ artist.save!
 queen = Artist.for('queen')
 hits = CD.for 'queens-greatest-hits'
 hits.artist == artist == queen
+bfc = Label.for('bfc')
+hits.label == label == bfc
 ```
 
 ### URIs and Blank Nodes
@@ -257,6 +269,10 @@ A class declares property members with the `property` function.  See `Property O
 
 A class declares list members with the `has_many` function.  See `Property Options` for more information.
 
+#### has_one
+
+A class declares singular association members with the `has_one` function.  See `Property Options` for more information.
+
 #### default_vocabulary
 
 A class with a `default_vocabulary` set will transparently create predicates for defined properties:
@@ -282,13 +298,15 @@ dancing_queen.has_predicate?(RDF::URI.new('http://example.org/vocab/artist')) #=
 ### Property Options
 
 Spira classes can have properties that are either singular or a list.  For a
-list, define the property with `has_many`, for a property with a single item,
-use `property`.  The semantics are otherwise the same.  A `has_many` property
-will always return a list, including an empty list for no value.  All options
-for `property` work for `has_many`.
+list, define the property with `has_many`.  For a property with a single item,
+use `has_one` for an associated Spira class, or `property` for any other type.
+The semantics are otherwise the same.  A `has_many` property will always return
+a list, including an empty list for no value.  All options for `property` work
+for `has_many` and `has_one`.
 
 ```ruby
 property :artist, :type => :artist    #=> cd.artist returns a single value
+has_one :label,   :type => :label     #=> cd.label returns a single value
 has_many :cds,    :type => :cd        #=> artist.cds returns an array
 ```
 

--- a/lib/spira/persistence.rb
+++ b/lib/spira/persistence.rb
@@ -311,7 +311,7 @@ module Spira
       if block_given?
         self.class.properties.each do |name, property|
           if value = read_attribute(name)
-            if self.class.reflect_on_association(name)
+            if self.class.reflections[name] && self.class.reflections[name].macro == :has_many
               value.each do |val|
                 node = build_rdf_value(val, property[:type])
                 yield RDF::Statement.new(subject, property[:predicate], node) if valid_object?(node)
@@ -399,7 +399,7 @@ module Spira
       repo = self.class.repository
       self.class.properties.each do |name, property|
         value = read_attribute name
-        if self.class.reflect_on_association(name)
+        if self.class.reflections[name] && self.class.reflections[name].macro == :has_many
           # TODO: for now, always persist associations,
           #       as it's impossible to reliably determine
           #       whether the "association property" was changed
@@ -444,7 +444,7 @@ module Spira
 
     # Directly retrieve an attribute value from the storage
     def retrieve_attribute(name, options, sts)
-      if self.class.reflections[name]
+      if self.class.reflections[name] && self.class.reflections[name].macro == :has_many
         sts.inject([]) do |values, statement|
           if statement.predicate == options[:predicate]
             values << build_value(statement.object, options[:type])

--- a/spec/fixtures/has_one.nt
+++ b/spec/fixtures/has_one.nt
@@ -1,0 +1,10 @@
+<http://example.org/posts/post1> <http://purl.org/dc/terms/title> "An example of a post" .
+<http://example.org/posts/post1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rdfs.org/sioc/ns#Post> .
+<http://example.org/posts/post1> <http://rdfs.org/sioc/ns#has_creator> <http://example.org/user_accounts/user_account1> .
+
+<http://example.org/user_accounts/user_account1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rdfs.org/sioc/ns#UserAccount> .
+<http://example.org/user_accounts/user_account1> <http://rdfs.org/sioc/ns#account_of> <http://example.org/people/person1> .
+<http://example.org/user_accounts/user_account1> <http://rdfs.org/sioc/ns#email> "user@example.org" .
+
+<http://example.org/people/person1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
+<http://example.org/people/person1> <http://xmlns.com/foaf/0.1/name> "Bob Smith" .

--- a/spec/has_one_spec.rb
+++ b/spec/has_one_spec.rb
@@ -1,0 +1,128 @@
+require "spec_helper"
+
+describe "has_one" do
+  before :all do
+    module ::HasOne
+      class Post < Spira::Base
+        type RDF::Vocab::SIOC.Post
+
+        has_one :creator, predicate: RDF::Vocab::SIOC.has_creator, type: "HasOne::UserAccount"
+        property :title, predicate: RDF::Vocab::DC.title
+      end
+
+      class UserAccount < Spira::Base
+        type RDF::Vocab::SIOC.UserAccount
+
+        has_one :account_of, predicate: RDF::Vocab::SIOC.account_of, type: "HasOne::Person"
+        property :email, predicate: RDF::Vocab::SIOC.email
+      end
+
+      class Person < Spira::Base
+        type RDF::Vocab::FOAF.Person
+
+        property :name, predicate: RDF::Vocab::FOAF.name
+      end
+    end
+  end
+
+  before :each do
+    Spira.repository = RDF::Repository.new
+  end
+
+  describe "Post" do
+    subject { HasOne::Post.new }
+
+    describe "method definitions" do
+      it { is_expected.to respond_to(:creator) }
+      it { is_expected.to respond_to(:creator=) }
+      it { is_expected.to respond_to(:build_creator) }
+      it { is_expected.to respond_to(:title) }
+      it { is_expected.to respond_to(:title=) }
+      it { is_expected.not_to respond_to(:build_title) }
+    end
+
+    describe "association builders" do
+      it "returns instances of associated class" do
+        expect(subject.build_creator).to be_a(HasOne::UserAccount)
+      end
+    end
+  end
+
+  describe "UserAccount" do
+    subject { HasOne::UserAccount.new }
+
+    describe "method definitions" do
+      it { is_expected.to respond_to(:account_of) }
+      it { is_expected.to respond_to(:account_of=) }
+      it { is_expected.to respond_to(:build_account_of) }
+      it { is_expected.to respond_to(:email) }
+      it { is_expected.to respond_to(:email=) }
+      it { is_expected.not_to respond_to(:build_email) }
+    end
+
+    describe "association builders" do
+      it "returns instances of associated class" do
+        expect(subject.build_account_of).to be_a(HasOne::Person)
+      end
+    end
+  end
+
+  describe "Person" do
+    subject { HasOne::Person.new }
+
+    describe "method definitions" do
+      it { is_expected.to respond_to(:name) }
+      it { is_expected.to respond_to(:name=) }
+      it { is_expected.not_to respond_to(:build_name) }
+    end
+  end
+
+  describe "loading from repository" do
+    before :each do
+      Spira.repository = RDF::Repository.load(fixture("has_one.nt"))
+    end
+
+    let(:post_uri) { RDF::URI.new("http://example.org/posts/post1") }
+    let(:user_account_uri) { RDF::URI.new("http://example.org/user_accounts/user_account1") }
+    let(:person_uri) { RDF::URI.new("http://example.org/people/person1") }
+
+    subject { HasOne::Post.for(post_uri) }
+
+    it "loads has_one associations" do
+      expect(subject.creator).to be_a(HasOne::UserAccount)
+      expect(subject.creator.subject).to eq(user_account_uri)
+      expect(subject.creator.account_of).to be_a(HasOne::Person)
+      expect(subject.creator.account_of.subject).to eq(person_uri)
+    end
+  end
+
+  describe "saving to repository" do
+    let(:person_uri) { RDF::URI.new("http://example.org/people/person1") }
+    let(:person) { HasOne::Person.for(person_uri, name: "Jane Jones") }
+
+    let(:user_account_uri) { RDF::URI.new("http://example.org/user_accounts/user_account1") }
+    let(:user_account) { HasOne::UserAccount.for(user_account_uri, account_of: person, email: "jane@example.org") }
+
+    let(:post_uri) { RDF::URI.new("http://example.org/posts/post1") }
+    let(:post) { HasOne::Post.for(post_uri, creator: user_account, title: "Jane Says") }
+
+    context "when object with has_one is saved" do
+      it "persists the object" do
+        post.save
+        expect(post).to be_persisted
+      end
+
+      it "saves the association triple" do
+        post.save
+        expect(Spira.repository.first_object(subject: post_uri, predicate: RDF::Vocab::SIOC.has_creator)).to eq(user_account_uri)
+      end
+
+      # TODO: would it be better if it *did* persist associated objects?
+      it "does not persist the associated object" do
+        post.save
+        expect(post.creator).not_to be_persisted
+        expect(post.creator.account_of).not_to be_persisted
+      end
+    end
+  end
+end


### PR DESCRIPTION
This introduces a `has_one` association alongside `property` and `has_many`.

The motivation is to distinguish on the model classes inheriting from `Spira::Base` between "local" properties on instances of that class, and instances of other `Spira::Base` model classes which would be seen instead as associations. It is envisaged that this could be built upon to offer support for nested attribute assignment (as with Active Record's `accepts_nested_attributes_for`).

* Adds `has_one` to sub-classes of `Spira::Base` with the same signature as `property` and `has_many`
* `has_one` associations define an instance builder method `#build_association` (as in Active Record)