### PR TITLE
Prevent repeated identicial queries to repository

### DIFF
--- a/lib/spira/persistence.rb
+++ b/lib/spira/persistence.rb
@@ -366,16 +366,17 @@ module Spira
     # NB: "props" argument is ignored, it is handled in Base
     #
     def reload(props = {})
-      sts = self.class.repository.query(:subject => subject)
+      query = self.class.repository.query(:subject => subject)
+      return if query.nil?
+
+      sts = query.map(&:itself)
+
       self.class.properties.each do |name, options|
         name = name.to_s
-        if sts
-          objects = sts.select { |s| s.predicate == options[:predicate] }
-          attributes[name] = retrieve_attribute(name, options, objects)
-        end
+        objects = sts.select { |s| s.predicate == options[:predicate] }
+        attributes[name] = retrieve_attribute(name, options, objects)
       end
     end
-
 
     private
 


### PR DESCRIPTION
Observed when using rdf-mongo for the repository adapter, `Spira::Persistence#reload` seems to result in multiple identical queries to the repository. (Once for each property on the model class?)

This change:
* exits early if the query response is `nil`
* otherwise reads all the statements from the query response once, preventing the duplicate queries to the repository