### PR TITLE
"RDF" module to should be prepended to all "register_alias" definitions

### DIFF
--- a/lib/spira/types/date.rb
+++ b/lib/spira/types/date.rb
@@ -20,7 +20,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.date)
     end
 
-    register_alias XSD.date
+    register_alias RDF::XSD.date
 
   end
 end

--- a/lib/spira/types/dateTime.rb
+++ b/lib/spira/types/dateTime.rb
@@ -20,7 +20,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.dateTime)
     end
 
-    register_alias XSD.dateTime
+    register_alias RDF::XSD.dateTime
 
   end
 end

--- a/lib/spira/types/gYear.rb
+++ b/lib/spira/types/gYear.rb
@@ -20,7 +20,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.gYear)
     end
 
-    register_alias XSD.gYear
+    register_alias RDF::XSD.gYear
 
   end
 end

--- a/lib/spira/types/int.rb
+++ b/lib/spira/types/int.rb
@@ -21,7 +21,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.int)
     end
 
-    register_alias XSD.int
+    register_alias RDF::XSD.int
 
   end
 end

--- a/lib/spira/types/long.rb
+++ b/lib/spira/types/long.rb
@@ -21,7 +21,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.long)
     end
 
-    register_alias XSD.long
+    register_alias RDF::XSD.long
 
   end
 end

--- a/lib/spira/types/negativeInteger.rb
+++ b/lib/spira/types/negativeInteger.rb
@@ -21,7 +21,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.negativeInteger)
     end
 
-    register_alias XSD.negativeInteger
+    register_alias RDF::XSD.negativeInteger
 
   end
 end

--- a/lib/spira/types/nonNegativeInteger.rb
+++ b/lib/spira/types/nonNegativeInteger.rb
@@ -21,7 +21,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.nonNegativeInteger)
     end
 
-    register_alias XSD.nonNegativeInteger
+    register_alias RDF::XSD.nonNegativeInteger
 
   end
 end

--- a/lib/spira/types/nonPositiveInteger.rb
+++ b/lib/spira/types/nonPositiveInteger.rb
@@ -21,7 +21,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.nonPositiveInteger)
     end
 
-    register_alias XSD.nonPositiveInteger
+    register_alias RDF::XSD.nonPositiveInteger
 
   end
 end

--- a/lib/spira/types/positiveInteger.rb
+++ b/lib/spira/types/positiveInteger.rb
@@ -21,7 +21,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.positiveInteger)
     end
 
-    register_alias XSD.positiveInteger
+    register_alias RDF::XSD.positiveInteger
 
   end
 end

--- a/lib/spira/types/time.rb
+++ b/lib/spira/types/time.rb
@@ -20,7 +20,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.time)
     end
 
-    register_alias XSD.time
+    register_alias RDF::XSD.time
 
   end
 end


### PR DESCRIPTION
On some systems, we have been getting a "NameError: uninitialized constant" error when
loading the Spira gem.

```
NameError: uninitialized constant Spira::Types::Int::XSD
gems/spira-3.1.0/lib/spira/types/int.rb:24:in `<class:Int>'
spira-3.1.0/lib/spira/types/int.rb:12:in `<module:Types>'
spira-3.1.0/lib/spira/types/int.rb:1:in `<top (required)>'
spira-3.1.0/lib/spira/types.rb:22:in `require'
spira-3.1.0/lib/spira/types.rb:22:in `block in <module:Types>'
spira-3.1.0/lib/spira/types.rb:22:in `each'
spira-3.1.0/lib/spira/types.rb:22:in `<module:Types>'
spira-3.1.0/lib/spira/types.rb:16:in `<module:Spira>'
spira-3.1.0/lib/spira/types.rb:1:in `<top (required)>'
spira-3.1.0/lib/spira/base.rb:384:in `require'
spira-3.1.0/lib/spira/base.rb:384:in `<class:Base>'
spira-3.1.0/lib/spira/base.rb:18:in `<module:Spira>'
spira-3.1.0/lib/spira/base.rb:12:in `<top (required)>'
...
```

The error has been perplexing because it does not occur at all on some systems, while consistently occurring on others. 

After some troubleshooting, it appears that the problem is that the classes in the "lib/spira/types" directory are inconsistent in their mention of the "RDF" module when calling the "register_alias" method.

The following files use "XSD" instead of "RDF::XSD" in their "register_alias" calls:

* date.rb
* dateTime.rb
* gYear.rb
* int.rb
* long.rb
* negativeInteger.rb
* nonNegativeInteger.rb
* nonPositiveInteger.rb
* positiveInteger.rb
* time.rb

The classes in the "lib/spira/types" directory are loaded by the "Types" module in "lib/spira/types.rb", and these classes are loaded in an arbitrary order. If one of the above classes is loaded first, a "NameError: uninitialized constant" error occurs because the "RDF" module has not yet been loaded by the system, and so the "XSD" constants are not available. If some other class which in the
"types" directory is loaded first (such as "anyURI.rb") which explicitly includes the "RDF" module
in the "register_alias" method, the error does not occur, because the "RDF" module is now available
when one of the classes above is loaded. Therefore the error is dependent on the order in which
the system loads the classes.

Prepending "RDF::" to the constant in the "register_alias" method of the above classes
makes the code more consistent and prevents this error from occurring, no matter the
order in which the classes are loaded.