### PR TITLE
require rdf/vocab in lib/spira.rb, closes #52

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ or to create a new store of RDF data based on simple defaults.
 
 An introductory blog post is at <http://blog.datagraph.org/2010/05/spira>
 
-A changelog is available in the {file:CHANGES.md} file.
+A changelog is available in the [CHANGES.md](CHANGES.md) file.
 
 ### Example
 
 ```ruby
+require 'spira'
+
 class Person < Spira::Base
 
   configure :base_uri => "http://example.org/example/people"

--- a/lib/spira.rb
+++ b/lib/spira.rb
@@ -3,6 +3,7 @@ require "rdf/ext/uri"
 require "promise"
 require "spira/exceptions"
 require "spira/utils"
+require "rdf/vocab"
 
 ##
 # Spira is a framework for building projections of RDF data into Ruby classes.


### PR DESCRIPTION
require rdf/vocab in lib/spira.rb
fix link to changelog